### PR TITLE
Make package.json more compatible for NPM frontend use

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
   "bugs": {
     "url": "https://github.com/openlayers/ol3/issues"
   },
+  "browser": {
+    "ol": "./node_modules/openlayers/dist/ol.js"
+  },
+  "style": [
+    "./node_modules/openlayers/css/ol.css"
+  ],
   "dependencies": {
     "async": "0.9.0",
     "closure-util": "1.4.0",


### PR DESCRIPTION
This PR augments package.json to ease OpenLayers 3 frontend development through NPM.
If you use Browserify and/or Parcelify, you can use news informations out of the box.
`browser` part is in [this spec](https://gist.github.com/defunctzombie/4339901)
See [this post on NPM blog](http://blog.npmjs.org/post/112712169830/making-your-jquery-plugin-work-better-with-npm) to understand my viewpoint and evaluate if it's worth to accept.

It's up to you to decide if providing paths to js and css is good. In fact, it's the same question as Bower users but we don't create a new file, we only use existing `package.json`.
